### PR TITLE
Remove Brotli from NGINX config

### DIFF
--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -18,21 +18,28 @@ jobs:
       TZ: Etc/GMT
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Link correct timezone to '/etc/localtime'
         run: ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
       - name: Run 'apt update'
         run: apt update
-      - name: Install package 'software-properties-common' and 'nginx'
-        run: apt install -y software-properties-common nginx
-      - name: Copy config 'nginx.conf.nginx-config' to '/etc/nginx/nginx.conf'
-        run: cp etc/nginx/nginx.conf.nginx-config /etc/nginx/nginx.conf
-      - name: Copy rest of configs
-        run: cp -a etc/nginx/conf.d etc/nginx/vhosts.d /etc/nginx/
+      - name: Install package 'software-properties-common', 'procps', 'curl' and 'nginx'
+        run: apt install -y software-properties-common nginx curl procps
+      - name: Copy config(s) to '/etc/nginx'
+        run: |
+             cp etc/nginx/nginx.conf.nginx-config /etc/nginx/nginx.conf
+             cp -a etc/nginx/conf.d etc/nginx/vhosts.d /etc/nginx/
+      - name: Create self-signed cert and DHE
+        run: |
+             mkdir -p /mnt/cert
+             curl https://ssl-config.mozilla.org/ffdhe2048.txt > /mnt/cert/nginx_dhe_4096.pem
+             # https://stackoverflow.com/questions/10175812/how-to-generate-a-self-signed-ssl-certificate-using-openssl
+             openssl req -x509 -newkey rsa:2048 -keyout /mnt/cert/www-ssl.key -out /mnt/cert/www-ssl.crt -sha256 -days 3650 -nodes -subj "/C=XX/ST=QAState/L=InQALand/O=QACorp/OU=QAUnit/CN=localhost"
       - name: Run nginx
-        run: nginx
+        run: |
+             nginx
       - name: Check if nginx is running
         run: |
              NGINX_RUNNING=$(pgrep -l nginx)
-             if [ -n "${NGINX_RUNNING}" ]; then exit 1; else ehcho "Nginx running"; fi
+             if [ -z "${NGINX_RUNNING}" ]; then echo "NGINX not running"; exit 1; else echo "NGINX running:${NGINX_RUNNING}"; fi
 

--- a/etc/nginx/nginx.conf.nginx-config
+++ b/etc/nginx/nginx.conf.nginx-config
@@ -17,21 +17,22 @@
 worker_processes 1;
 
 # Brotli provides faster compression with less usage of CPU
-load_module /usr/lib64/nginx/modules/ngx_http_brotli_filter_module.so;
-load_module /usr/lib64/nginx/modules/ngx_http_brotli_static_module.so;
-# load_module lib64/nginx/modules/ngx_http_fancyindex_module.so;
-# load_module lib64/nginx/modules/ngx_http_headers_more_filter_module.so;
-# load_module lib64/nginx/modules/ngx_http_image_filter_module.so;
-# load_module lib64/nginx/modules/ngx_http_perl_module.so;
-# load_module lib64/nginx/modules/ngx_http_xslt_filter_module.so;
-# load_module lib64/nginx/modules/ngx_mail_module.so;
+# As it's not available Ubuntu remove the modules.
+# If needed then just uncomment and correct location
+# load_module /usr/lib64/nginx/modules/ngx_http_brotli_filter_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_http_brotli_static_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_http_fancyindex_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_http_headers_more_filter_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_http_image_filter_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_http_perl_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_http_xslt_filter_module.so;
+# load_module /usr/lib64/nginx/modules/ngx_mail_module.so;
 # load_module lib64/nginx/modules/ngx_rtmp_module.so;
 # load_module lib64/nginx/modules/ngx_stream_module.so;
 
 #error_log  /var/log/nginx/error.log;
 #error_log  /var/log/nginx/error.log  notice;
 #error_log  /var/log/nginx/error.log  info;
-
 #pid        /var/run/nginx.pid;
 events {
     worker_connections 1024;
@@ -96,15 +97,15 @@ http {
     # gzip_min_length
     # gzip_proxied any;
     # gzip
-    include conf.d/compression/*.conf;
-    # Include external compression modules: brotli
+    include conf.d/compression/gzip.conf;
+    # Include compresion modules: brotli
     # /etc/nginx/conf.d/compression/ext/brotli.conf
     # brotli_types
     # brotli_comp_level
     # brotli_static
     # brotli_min_length
     # brotli
-    include conf.d/compression/ext/*.conf;
+    # include conf.d/compression/ext/brotli.conf;
 
     # Include configure for port 80. It's located /etc/nginx/vhosts.d/port80redirect.conf
     # For running this NginX use /usr/bin/nginx-launch.sh or /usr/bin/basicssl-nginx-container-launch.sh


### PR DESCRIPTION
As Brotli module NGINX is not default in most of distro comment it out. If needed one should uncomment and start using.