### PR TITLE
Changing blocks to return 403 for easier testing

### DIFF
--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -31,6 +31,10 @@ jobs:
         run: apt update -qq
       - name: Install package 'curl', 'lsof', 'nginx' ,'procps', 'psmisc' and 'software-properties-common' 
         run: apt install -y curl lsof nginx procps psmisc software-properties-common
+      - name: Install package 'hurl'
+        run: |
+             curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.2.0/hurl_4.2.0_amd64.deb
+             dpkg -i hurl_4.2.0_amd64.deb
       - name: Copy config(s) to '/etc/nginx'
         run: |
              cp etc/nginx/nginx.conf.nginx-config /etc/nginx/nginx.conf
@@ -66,13 +70,4 @@ jobs:
              if [ -z "${NGINX_LISTENING}" ]; then echo "Port 8443 should be listening"; exit 1; else echo "Port 8443 listening: OK"; fi
       - name: Check port HTTP 8080 and HTTPS 8443 with curl
         run: |
-             curl http://localhost:8080 > /tmp/port8080.html 2> /dev/null
-             NGINX_MOVED=$(grep "301 Moved Permanently" /tmp/port8080.html)
-             if [ -z "${NGINX_MOVED}" ]; then echo "Wrong answer from NGINX port 8080: ${NGINX_MOVED}"; exit 1; else echo "NGINX: Correct 301 redirect from HTTP"; fi
-             curl -v --stderr /tmp/port8080.html http://localhost:8080/this/is/test > /dev/null
-             NGINX_MOVED=$(grep "Location: https://localhost/this/is/test" /tmp/port8080.html)
-             if [ -z "${NGINX_MOVED}" ]; then echo "Wrong answer from NGINX port 8080: ${NGINX_MOVED}"; exit 1; else echo "NGINX: Redirects to correct HTTPS"; fi
-             curl -k https://localhost:8443 > /tmp/port8443.html 2> /dev/null
-             NGINX_MOVED=$(diff -urN /tmp/port8443.html srv/www/htdocs/container-root/index.html)
-             if [ -n "${NGINX_MOVED}" ]; then echo "Wrong answer from NGINX port 8443: ${NGINX_MOVED}"; exit 1; else echo "NGINX: Get correct answer from HTTPS index.html"; fi
-
+             hurl --verbose --cacert /mnt/cert/www-ssl.crt --test test/http-basic.hurl

--- a/etc/nginx/conf.d/blocks/cgi_locations.conf
+++ b/etc/nginx/conf.d/blocks/cgi_locations.conf
@@ -1,3 +1,3 @@
 if ( $is_cgi_uri = 1 ) {
-    return 444;
+    return 403;
 }

--- a/etc/nginx/conf.d/blocks/http_agent.conf
+++ b/etc/nginx/conf.d/blocks/http_agent.conf
@@ -1,3 +1,3 @@
 if ( $is_bad_agent = 1 ) {
-    return 444;
+    return 403;
 }

--- a/etc/nginx/conf.d/blocks/methods.conf
+++ b/etc/nginx/conf.d/blocks/methods.conf
@@ -1,4 +1,4 @@
 if ($request_method !~ ^(POST|GET)) {
-    return 444;
+    return 403;
 }
 

--- a/etc/nginx/conf.d/blocks/sensitive_locations.conf
+++ b/etc/nginx/conf.d/blocks/sensitive_locations.conf
@@ -1,4 +1,4 @@
 if ( $is_sensitive_uri = 1 ) {
-    return 444;
+    return 403;
 }
 

--- a/etc/nginx/conf.d/blocks/special_attack.conf
+++ b/etc/nginx/conf.d/blocks/special_attack.conf
@@ -1,3 +1,3 @@
 if ( $is_uri_special = 1 ) {
-    return 444;
+    return 403;
 }

--- a/etc/nginx/conf.d/blocks/special_map.conf
+++ b/etc/nginx/conf.d/blocks/special_map.conf
@@ -1,6 +1,6 @@
 # This is MAP for server well or not so
 # well known attacks that should be just
-# dropped and returned 444
+# dropped and returned 403
 map $request_uri $is_uri_special {
     default 0;
     # Ghost

--- a/etc/nginx/conf.d/max_post.conf
+++ b/etc/nginx/conf.d/max_post.conf
@@ -38,4 +38,10 @@ types_hash_max_size 8192;
 # The “Keep-Alive: timeout=time” header field is recognized by Mozilla and Konqueror.
 # MSIE closes keep-alive connections by itself in about 60 seconds.
 # http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
-keepalive_timeout 90;
+keepalive_timeout 45;
+
+# Sets the maximum number of requests that can be served through one keep-alive connection.
+# After the maximum number of requests are made, the connection is closed. 
+# https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests
+keepalive_requests 100;
+

--- a/etc/nginx/nginx.conf.nginx-config
+++ b/etc/nginx/nginx.conf.nginx-config
@@ -1,7 +1,7 @@
 #
 # This file is part of
 # https://github.com/illuusio/nginx-config
-# It's meant to replace /etc/nginx/nginx.conf
+# It's meant to replace nginx.conf
 # if one want's to use project
 #
 # Multiple (mostly all) nginx project
@@ -35,85 +35,103 @@ worker_processes 1;
 #error_log  /var/log/nginx/error.log  info;
 #pid        /var/run/nginx.pid;
 events {
-    worker_connections 1024;
-    use epoll;
+	worker_connections 1024;
+	use epoll;
 }
 
-
 http {
-    include mime.types;
-    default_type application/octet-stream;
+	include mime.types;
+	default_type application/octet-stream;
 
-    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    #                  '$status $body_bytes_sent "$http_referer" '
-    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+	#log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+	#                  '$status $body_bytes_sent "$http_referer" '
+	#                  '"$http_user_agent" "$http_x_forwarded_for"';
 
-    #access_log  /var/log/nginx/access.log  main;
-    # Include SSL and other tunings like:
-    # /etc/nginx/conf.d/max_post.conf
-    # sendfile
-    # sendfile_max_chunk
-    # tcp_nopush
-    # tcp_nodelay
-    # client_max_body_size
-    # types_hash_max_size
-    # keepalive_timeout
-    #
-    # etc/nginx/conf.d/cache.conf
-    # proxy_read_timeout
-    # proxy_connect_timeout
-    # proxy_send_timeout
-    #
-    # /etc/nginx/conf.d/security.conf
-    # charset
-    # server_tokens
-    #
-    # /etc/nginx/conf.d/ssl_global.conf
-    # ssl_certificate
-    # ssl_certificate_key
-    #
-    # cat etc/nginx/conf.d/ssl_ocsp.conf
-    # ssl_stapling
-    # ssl_stapling_verify
-    #
-    # /etc/nginx/conf.d/ssl_params.conf
-    # ssl_dhparam
-    # ssl_protocols
-    # ssl_ciphers
-    # ssl_prefer_server_ciphers
-    # ssl_trusted_certificate
-    # ssl_ecdh_curve secp384r1;
-    #
-    # /etc/nginx/conf.d/ssl_session.conf
-    # ssl_session_timeout
-    # ssl_session_cache
-    # ssl_session_tickets
-    include conf.d/*.conf;
-    # Include compresion modules: gzip
-    # /etc/nginx/conf.d/compression/gzip.conf
-    # gzip_types
-    # gzip_comp_level
-    # gzip_vary
-    # gzip_buffers
-    # gzip_min_length
-    # gzip_proxied any;
-    # gzip
-    include conf.d/compression/gzip.conf;
-    # Include compresion modules: brotli
-    # /etc/nginx/conf.d/compression/ext/brotli.conf
-    # brotli_types
-    # brotli_comp_level
-    # brotli_static
-    # brotli_min_length
-    # brotli
-    # include conf.d/compression/ext/brotli.conf;
+	#access_log  /var/log/nginx/access.log  main;
+	# Include SSL and other tunings like:
+	# conf.d/max_post.conf
+	# sendfile
+	# sendfile_max_chunk
+	# tcp_nopush
+	# tcp_nodelay
+	# client_max_body_size
+	# types_hash_max_size
+	# keepalive_timeout
+	#
+	# etc/nginx/conf.d/cache.conf
+	# proxy_read_timeout
+	# proxy_connect_timeout
+	# proxy_send_timeout
+	#
+	# conf.d/security.conf
+	# charset
+	# server_tokens
+	#
+	# conf.d/ssl_global.conf
+	# ssl_certificate
+	# ssl_certificate_key
+	#
+	# cat etc/nginx/conf.d/ssl_ocsp.conf
+	# ssl_stapling
+	# ssl_stapling_verify
+	#
+	# conf.d/ssl_params.conf
+	# ssl_dhparam
+	# ssl_protocols
+	# ssl_ciphers
+	# ssl_prefer_server_ciphers
+	# ssl_trusted_certificate
+	# ssl_ecdh_curve secp384r1;
+	#
+	# conf.d/ssl_session.conf
+	# ssl_session_timeout
+	# ssl_session_cache
+	# ssl_session_tickets
+	include conf.d/*.conf;
+	# Include compresion modules: gzip
+	# conf.d/compression/gzip.conf
+	# gzip_types
+	# gzip_comp_level
+	# gzip_vary
+	# gzip_buffers
+	# gzip_min_length
+	# gzip_proxied any;
+	# gzip
+	include conf.d/compression/gzip.conf;
+	# Include compresion modules: brotli
+	# conf.d/compression/ext/brotli.conf
+	# brotli_types
+	# brotli_comp_level
+	# brotli_static
+	# brotli_min_length
+	# brotli
+	# include conf.d/compression/ext/brotli.conf;
 
-    # Include configure for port 80. It's located /etc/nginx/vhosts.d/port80redirect.conf
-    # For running this NginX use /usr/bin/nginx-launch.sh or /usr/bin/basicssl-nginx-container-launch.sh
-    include vhosts.d/*.conf;
-    # If running under Debian or Ubuntu this is correct
-    # location for vhosts.d
-    # include sites-enabled/*;
+	# Do not allow sensitive locations sniffing
+	# HTTP code 444 returned if in map
+	include conf.d/blocks/sensitive_map.conf;
+
+	# Remove some CGI sniffing locations
+	# HTTP code 444 returned if in map
+	include conf.d/blocks/cgi_map.conf;
+
+	# Do not allow malicious bots
+	# HTTP code 444 if in list
+	include conf.d/blocks/http_agent_map.conf;
+
+	# These are mainly fishing and should be ignore
+	# Host that do these kind of script attacks should
+	# be set to drop on firewall or at least block because
+	# otherwise they just for what they do until the end of universe
+	# HTTP code 444 if in list
+	include conf.d/blocks/special_map.conf;
+
+	# Include configure for port 80. It's located vhosts.d/port80redirect.conf
+	# For running this NginX use /usr/bin/nginx-launch.sh or /usr/bin/basicssl-nginx-container-launch.sh
+	include vhosts.d/*.conf;
+	# If running under Debian or Ubuntu this is correct
+	# location for vhosts.d
+	# include sites-enabled/*;
 }
 
 # If one wants RTMP streaming things should be here

--- a/etc/nginx/vhosts.d/port80redirect.conf
+++ b/etc/nginx/vhosts.d/port80redirect.conf
@@ -5,25 +5,6 @@
 # Port 8080 is port 80
 # This needs to be notified if used in container
 
-# Do not allow sensitive locations sniffing
-# HTTP code 444 returned if in map
-include /etc/nginx/conf.d/blocks/sensitive_map.conf;
-
-# Remove some CGI sniffing locations
-# HTTP code 444 returned if in map
-include /etc/nginx/conf.d/blocks/cgi_map.conf;
-
-# Do not allow malicious bots
-# HTTP code 444 if in list
-include /etc/nginx/conf.d/blocks/http_agent_map.conf;
-
-# These are mainly fishing and should be ignore
-# Host that do these kind of script attacks should
-# be set to drop on firewall or at least block because
-# otherwise they just for what they do until the end of universe
-# HTTP code 444 if in list
-include /etc/nginx/conf.d/blocks/special_map.conf;
-
 server {
     listen 8080;
 

--- a/etc/nginx/vhosts.d/sites/port443.conf.example
+++ b/etc/nginx/vhosts.d/sites/port443.conf.example
@@ -3,25 +3,6 @@
 # Port 8443 is port 443
 # This needs to be notified if used in container
 
-# Do not allow sensitive locations sniffing
-# HTTP code 444 returned if in map
-include /etc/nginx/conf.d/blocks/sensitive_map.conf;
-
-# Remove some CGI sniffing locations
-# HTTP code 444 returned if in map
-include /etc/nginx/conf.d/blocks/cgi_map.conf;
-
-# Do not allow malicious bots
-# HTTP code 444 if in list
-include /etc/nginx/conf.d/blocks/http_agent_map.conf;
-
-# These are mainly fishing and should be ignore
-# Host that do these kind of script attacks should
-# be set to drop on firewall or at least block because
-# otherwise they just for what they do until the end of universe
-# HTTP code 444 if in list
-include /etc/nginx/conf.d/blocks/special_map.conf;
-
 server {
     listen 8443 ssl http2;
 

--- a/test/http-basic.hurl
+++ b/test/http-basic.hurl
@@ -1,0 +1,47 @@
+# test that HTTP redirects to HTTPS
+GET http://localhost:8080/test
+HTTP 301
+
+[Asserts]
+header "Location" exists
+header "Location" contains "test"
+header "Server" contains "nginx"
+
+# Test that bad agent won't be redirected
+GET http://localhost:8080/
+User-Agent: Hello, world
+HTTP 403
+
+# Test that bad location won't be redirected
+GET http://localhost:8080/.env
+HTTP 403
+
+# test that HTTP redirects to HTTPS
+GET https://localhost:8443/
+HTTP 200
+
+[Asserts]
+header "Content-Type" matches "text/html; charset=utf-8"
+header "Server" matches "nginx"
+# header "Connection" matches "keep-alive"
+header "Cache-Control" matches "public, max-age=15778463"
+header "Referrer-Policy" matches "no-referrer-when-downgrade"
+header "Strict-Transport-Security" matches "max-age=31536000; includeSubDomains"
+header "X-Content-Type-Options" matches "nosniff"
+header "X-Download-Options" matches "noopen"
+header "X-Frame-Options" matches "SAMEORIGIN"
+header "X-Permitted-Cross-Domain-Policies" matches "none"
+header "X-Robots-Tag" matches "nofollow, nosnippet, noarchive"
+header "X-XSS-Protection" matches "1; mode=block"
+header "Content-Security-Policy" matches "default-src 'self' http: https: data: blob: 'unsafe-inline'"
+body contains "<title>Placeholder for the future</title>"
+body contains "<h1>As you may noticed <u>nothing to see here</u></h1>"
+
+# Test that bad agent fails also on https
+GET https://localhost:8443/test
+User-Agent: Hello, world
+HTTP 403
+
+# Test that bad file won't be served
+GET https://localhost:8443/.env
+HTTP 403


### PR DESCRIPTION
After changing Github CI testing support for
HURL (https://github.com/Orange-OpenSource/hurl)
returning non official HTTP 444 feels bit overkill and changed to blocks to return '403 Unauthorized' which is seems to be more correct.

If changes backslashes '444 No Response' will be returned

Also tune blocking files to be include in
global in nginx master config nginx.conf.nginx-config