### PR TITLE
Make reverse proxy work with blocks

### DIFF
--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -1,5 +1,5 @@
 ---
-name: Test configuration on NGINX 
+name: Test configuration on NGINX
 
 on:
   workflow_call:
@@ -41,13 +41,17 @@ jobs:
              cp -a etc/nginx/conf.d /etc/nginx/
              cp etc/nginx/vhosts.d/port80redirect.conf /etc/nginx/sites-enabled/default
              cp etc/nginx/vhosts.d/sites/port443.conf.example /etc/nginx/sites-enabled/port443
+             cp etc/nginx/vhosts.d/sites/reverse_proxy.conf.example /etc/nginx/sites-enabled/reverse_proxy
              mkdir -p /var/www/html/container-root
              cp srv/www/htdocs/container-root/index.html /var/www/html/container-root
+             mkdir -p /var/www/html/container-root/frontend_latest
+             echo "console.log("test");" > /var/www/html/container-root/frontend_latest/test.js
+             echo "console.log("test");" > /var/www/html/container-root/frontend_latest/core.5SVJjOh2U7M.js
       - name: Tune configs in '/etc/nginx'
         run: |
              sed -i "s/include vhosts.d\/\*\.conf/# include vhosts.d\/\*\.conf/" /etc/nginx/nginx.conf
              sed -i "s/# include sites-enabled\/\*/include sites-enabled\/\*/" /etc/nginx/nginx.conf
-             sed -i "s/\/srv\/www\/htdocs/\/var\/www\/html/" /etc/nginx/sites-enabled/port443
+             sed -i "s/\/srv\/www\/htdocs/\/var\/www\/html/" /etc/nginx/sites-enabled/*
       - name: Create self-signed cert and DHE
         run: |
              mkdir -p /mnt/cert

--- a/etc/nginx/conf.d/blocks/README.md
+++ b/etc/nginx/conf.d/blocks/README.md
@@ -9,6 +9,9 @@ annoyance from bots and location snooping script kiddies
 ## locations.conf
 - Make some tuning for your site cache
 
+## expires.conf
+- Expires control for something else than reverse proxying
+
 ## methods.conf
 - Just enable HTTP methods HEAD, GET and POST
 

--- a/etc/nginx/conf.d/blocks/expires.conf
+++ b/etc/nginx/conf.d/blocks/expires.conf
@@ -1,0 +1,15 @@
+#
+# This can't be used with reverse proxy
+# We can't know how reverse proxy server
+# will do it
+#
+
+# assets, media
+location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
+    expires 7d;
+}
+
+# svg, fonts
+location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
+    expires 7d;
+}

--- a/etc/nginx/conf.d/blocks/locations.conf
+++ b/etc/nginx/conf.d/blocks/locations.conf
@@ -5,24 +5,17 @@
 #    deny all;
 # }
 
-# favicon.ico
+# favicon.ico do not add to log or if it's not found
+# do not log that neither
 location = /favicon.ico {
     log_not_found off;
     access_log off;
 }
 
-# robots.txt
+# robots.txt is something that is not error
+# if it's not found
 location = /robots.txt {
     log_not_found off;
     access_log off;
 }
 
-# assets, media
-location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
-    expires 7d;
-}
-
-# svg, fonts
-location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
-    expires 7d;
-}

--- a/etc/nginx/vhosts.d/sites/port443.conf.example
+++ b/etc/nginx/vhosts.d/sites/port443.conf.example
@@ -13,6 +13,9 @@ server {
     # Some minor tuning how caches will behave
     include /etc/nginx/conf.d/blocks/locations.conf;
 
+    # Some minor tuning how caches will behave
+    include /etc/nginx/conf.d/blocks/expires.conf;
+
     # Only allow HEAD, GET and POST
     # Otherwise code 444 returned
     include /etc/nginx/conf.d/blocks/methods.conf;

--- a/etc/nginx/vhosts.d/sites/reverse_proxy.conf.example
+++ b/etc/nginx/vhosts.d/sites/reverse_proxy.conf.example
@@ -1,18 +1,17 @@
-# Port 80 router to https for NGinX
-# As one can use 80 port as user (mostly nginx)
-# Port has to be above 1024.
-#
-# Port 8080 is port 80
-# This needs to be notified if used in container
-
 server {
-    listen 8080;
+    listen 8444 ssl http2;
+    
+    server_name localhost;
+    root /srv/www/htdocs/container-root/;
+    index index.html index.htm index.nginx-debian.html;
+
+    access_log /var/log/nginx/reverse_proxy-ssl-access.log;
+    error_log /var/log/nginx/reverse_proxy-ssl-error.log;
+
+    proxy_buffering off;
 
     # Some minor tuning how caches will behave
-    include conf.d/blocks/locations.conf;
-
-    # Some minor tuning how caches will behave
-    include conf.d/blocks/expires.conf;
+    # include conf.d/blocks/locations.conf;
 
     # Only allow HEAD, GET and POST
     # Otherwise code 444 returned
@@ -36,11 +35,15 @@ server {
     # HTTP code 444 returned if in map
     include conf.d/blocks/cgi_locations.conf;
 
-    # server_name example.com;
+    location / {
+      proxy_pass https://127.0.0.1:8443;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
 
-    access_log /var/log/nginx/port80_access.log;
-    error_log /var/log/nginx/port80_error.log;
-
-    # Return Redirect to HTTPS
-    return 301 https://$host$request_uri;
 }

--- a/test/http-basic.hurl
+++ b/test/http-basic.hurl
@@ -45,3 +45,37 @@ HTTP 403
 # Test that bad file won't be served
 GET https://localhost:8443/.env
 HTTP 403
+
+# Test that subdir works
+GET https://localhost:8443/frontend_latest/test.js
+HTTP 200
+
+# Test that some spefic file works
+GET https://localhost:8443/frontend_latest/core.5SVJjOh2U7M.js
+HTTP 200
+
+# Test that some spefic file works
+GET https://localhost:8443/frontend_latest/.env
+HTTP 403
+
+# Test reverse proxy
+# This needs etc/nginx/vhost.d/reverse_proxy.conf.tmpl
+GET https://localhost:8444/test
+User-Agent: Hello, world
+HTTP 403
+
+# Test that bad file won't be served
+GET https://localhost:8444/.env
+HTTP 403
+
+# Test that subdir works
+GET https://localhost:8444/frontend_latest/test.js
+HTTP 200
+
+# Test that some spefic file works
+GET https://localhost:8444/frontend_latest/core.5SVJjOh2U7M.js
+HTTP 200
+
+# Test that some spefic file works
+GET https://localhost:8444/frontend_latest/.env
+HTTP 403


### PR DESCRIPTION
There were problem in etc/nginx/conf.d/blocks/locations.conf that caused return of 404 (Not Found) when requested file from sub dir. This was because of using expires header and they are not supposed to be used with reverse proxy.

Move those expires to etc/nginx/conf.d/blocks/expires.conf which should be included if used in local Nginx and not in reverse proxy.

Added also needed tests for HURL and configuration for reverse proxy.