### PR TITLE
Home Assistant hit mercurial banning with 11203.hgzrYFbg5F4.js string

### DIFF
--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -51,6 +51,7 @@ jobs:
              echo "console.log("test");" > /var/www/html/container-root/frontend_latest/test.js
              echo "console.log("test");" > /var/www/html/container-root/frontend_latest/core.5SVJjOh2U7M.js
              echo "console.log("test");" > /var/www/html/container-root/frontend_latest/13255.4EVdx_9MOD4.js
+             echo "console.log("test");" > /var/www/html/container-root/frontend_latest/11203.hgzrYFbg5F4.js
              echo "console.log("test");" > /var/www/html/container-root/sw-modern.js
       - name: Tune configs in '/etc/nginx'
         run: |

--- a/etc/nginx/conf.d/blocks/sensitive_map.conf
+++ b/etc/nginx/conf.d/blocks/sensitive_map.conf
@@ -79,12 +79,14 @@ map $uri $is_sensitive_uri {
     "~*\.fhp$" 1;
     "~*\.forward$" 1;
     "~*\.fr$" 1;
-    "~*\.git" 1;
+    "~*/\.git" 1;
+    "~*\.git/.*$" 1;
     "~*\.github" 1;
     "~*\.gitlab" 1;
     "~*\.grp$" 1;
     "~*\.gz$" 1;
-    "~*\.hg" 1;
+    "~*/\.hg" 1;
+    "~*\.hg/.*$" 1;
     "~*\.history$" 1;
     "~*/hnap1$" 1;
     "~*\.home$" 1;

--- a/test/http-homeassistant.hurl
+++ b/test/http-homeassistant.hurl
@@ -16,6 +16,11 @@ GET https://localhost:8443/frontend_latest/13255.4EVdx_9MOD4.js
 User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
 HTTP 200
 
+GET https://localhost:8443/frontend_latest/11203.hgzrYFbg5F4.js
+User-Agent: Mozilla/5.0 (Linux; Android 14; CPH2493 Build/UKQ1.230924.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.39 Mobile Safari/537.36
+Referer: https://localhost:8443/sw-modern.js
+HTTP 200
+
 GET https://localhost:8443/api/camera_proxy/camera.just_a_cam?authSig=h5TBq9jlqqv73h8jypq9DS60E0XFxh3g7ZAQES6JLCMuFvMDNtd/9ohQ+/W2qBTVHEUf6/Dhc+iiO06IvcFw/7I4E8a0Es1myHYg4eZX4f6Ew7MV+QOWpVRJ8dVtqHNz&width=980&height=552
 User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
 Referer: https://localhost:8443/lovelace/0
@@ -35,6 +40,11 @@ HTTP 200
 
 GET https://localhost:8444/frontend_latest/13255.4EVdx_9MOD4.js
 User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 200
+
+GET https://localhost:8444/frontend_latest/11203.hgzrYFbg5F4.js
+User-Agent: Mozilla/5.0 (Linux; Android 14; CPH2493 Build/UKQ1.230924.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.39 Mobile Safari/537.36
+Referer: https://localhost:8443/sw-modern.js
 HTTP 200
 
 GET https://localhost:8444/api/camera_proxy/camera.just_a_cam?authSig=h5TBq9jlqqv73h8jypq9DS60E0XFxh3g7ZAQES6JLCMuFvMDNtd/9ohQ+/W2qBTVaHEUf6/Dhc+iiO06IvcFw/7I4E8a0Es1myHYg4eZX4f6Ew7MV+QOWpVRJ8dVtqHNz&width=980&height=552

--- a/test/http-sensetive.hurl
+++ b/test/http-sensetive.hurl
@@ -694,6 +694,16 @@ HTTP 403
 GET https://localhost:8443/.gitC3KsYCxK
 HTTP 403
 
+GET https://localhost:8443/.git/file
+HTTP 403
+
+GET https://localhost:8443/.git/file?param=o0rZdP0E&another=12887
+HTTP 403
+
+GET https://localhost:8443/.git/fileC3KsYCxK
+HTTP 403
+
+
 GET https://localhost:8443/.github
 HTTP 403
 
@@ -738,6 +748,16 @@ HTTP 403
 
 GET https://localhost:8443/.hgYPnon0N
 HTTP 403
+
+GET https://localhost:8443/.hg/file
+HTTP 403
+
+GET https://localhost:8443/.hg/file/?param=Qs59XBhr&another=24369
+HTTP 403
+
+GET https://localhost:8443/.hg/file.YPnon0N
+HTTP 403
+
 
 GET https://localhost:8443/file.history
 HTTP 403


### PR DESCRIPTION
Home Assistant makes random '<five digits>.<11 random chars and digits>.js' names which could mess with .hg and .git (and some others). Now fixed that they should not mess anything up anymore and nobody gets banned.

This fixes '11203.hgzrYFbg5F4.js' which hitted .hg which is mercurial sensetive directory