### PR TITLE
Update workflows with new Hurl and Debian Sid fixed

### DIFF
--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Run 'apt update'
         run: apt update -qq
       - name: Install package 'curl', 'lsof', 'nginx' ,'procps' and 'psmisc'
-        run: apt install -y libcurl4 curl lsof nginx procps psmisc
+        run: apt install -y libcurl4 curl lsof nginx procps psmisc libxml2
       - name: Install package 'hurl'
         run: |
-             curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.2.0/hurl_4.2.0_amd64.deb
-             dpkg -i hurl_4.2.0_amd64.deb
+             curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
+             dpkg -i hurl_5.0.1_amd64.deb
       - name: Copy config(s) to '/etc/nginx'
         run: |
              cp etc/nginx/nginx.conf.nginx-config /etc/nginx/nginx.conf

--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -29,8 +29,8 @@ jobs:
         run: echo 'APT::Update::Error-Mode "any";' > /etc/apt/apt.conf.d/non-zero-exit-on-warnings
       - name: Run 'apt update'
         run: apt update -qq
-      - name: Install package 'curl', 'lsof', 'nginx' ,'procps', 'psmisc' and 'software-properties-common' 
-        run: apt install -y libcurl4 curl lsof nginx procps psmisc software-properties-common
+      - name: Install package 'curl', 'lsof', 'nginx' ,'procps' and 'psmisc'
+        run: apt install -y libcurl4 curl lsof nginx procps psmisc
       - name: Install package 'hurl'
         run: |
              curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.2.0/hurl_4.2.0_amd64.deb


### PR DESCRIPTION
Update newer Hurl (version 5.0.1) and remove software-properties-common package which is gone in sid and not needed for testing.