### PR TITLE
Add test for Wordpress site phishing

### DIFF
--- a/etc/nginx/conf.d/blocks/wordpress_locations.conf
+++ b/etc/nginx/conf.d/blocks/wordpress_locations.conf
@@ -1,0 +1,4 @@
+if ( $is_wordpress_uri = 1 ) {
+	return 418;
+}
+

--- a/etc/nginx/conf.d/blocks/wordpress_map.conf
+++ b/etc/nginx/conf.d/blocks/wordpress_map.conf
@@ -1,0 +1,7 @@
+map $uri $is_wordpress_uri {
+	default 0;
+	"~*/[2018|2019|2020|blog|cms|media|news|shop|site|sito|test|website|wordpress]/wp-includes/wlwmanifest.xml" 1;
+	"~*/wp-includes/wlwmanifest.xml" 1;
+	"~*/wordpress/setup-config.php" 1;
+	"~*/wp-admin/setup-config.php" 1;
+}

--- a/etc/nginx/nginx.conf.nginx-config
+++ b/etc/nginx/nginx.conf.nginx-config
@@ -111,6 +111,12 @@ http {
 	# HTTP code 444 returned if in map
 	include conf.d/blocks/sensitive_map.conf;
 
+	# Wordpress sniffing URL's if don't host Wordpress you should
+	# use these and if you do then you should probably keep wp-admin
+	# somewhere else
+	# HTTP code 418 returned if in map
+	include conf.d/blocks/wordpress_map.conf;
+
 	# Cache control map
 	include conf.d/blocks/expires_map.conf;
 

--- a/etc/nginx/vhosts.d/examples/phpmyadmin.conf.example
+++ b/etc/nginx/vhosts.d/examples/phpmyadmin.conf.example
@@ -1,6 +1,6 @@
 server {
-    listen 8443 ssl;
-    listen [::]:8443 ssl;
+    listen 8443 ssl http2;
+    listen [::]:8443 ssl http2;
 
     server_name localhost;
     root /usr/share/phpMyAdmin;
@@ -29,6 +29,12 @@ server {
     # Do not allow sensitive locations sniffing
     # HTTP code 444 returned if in map
     include /etc/nginx/conf.d/blocks/sensitive_locations.conf;
+    
+    # Wordpress sniffing URL's if don't host Wordpress you should
+    # use these and if you do then you should probably keep wp-admin
+    # somewhere else
+    # HTTP code 418 returned if in map
+    include conf.d/blocks/wordpress_locations.conf;
 
     # Remove some CGI sniffing locations
     # HTTP code 444 returned if in map

--- a/etc/nginx/vhosts.d/examples/port443.conf.example
+++ b/etc/nginx/vhosts.d/examples/port443.conf.example
@@ -11,35 +11,41 @@ server {
     index index.html index.htm index.nginx-debian.html;
 
     # Some minor tuning how caches will behave
-    include /etc/nginx/conf.d/blocks/locations.conf;
+    include conf.d/blocks/locations.conf;
 
     # Some minor tuning how caches will behave
-    include /etc/nginx/conf.d/blocks/expires.conf;
+    include conf.d/blocks/expires.conf;
 
     # Only allow HEAD, GET and POST
     # Otherwise code 444 returned
-    include /etc/nginx/conf.d/blocks/methods.conf;
+    # include conf.d/blocks/methods.conf;
 
     # Mainly stuff that are done with script and
     # attacks against PHP based systems. Most of
     # them try to install rootkit
     # HTTP code 444 returned if in map
-    include /etc/nginx/conf.d/blocks/special_attack.conf;
+    include conf.d/blocks/special_attack.conf;
 
     # Do not allow sensitive locations sniffing
     # HTTP code 444 returned if in map
-    include /etc/nginx/conf.d/blocks/http_agent.conf;
+    include conf.d/blocks/http_agent.conf;
 
     # Do not allow sensitive locations sniffing
     # HTTP code 444 returned if in map
-    include /etc/nginx/conf.d/blocks/sensitive_locations.conf;
+    include conf.d/blocks/sensitive_locations.conf;
+
+    # Wordpress sniffing URL's if don't host Wordpress you should
+    # use these and if you do then you should probably keep wp-admin
+    # somewhere else
+    # HTTP code 418 returned if in map
+    include conf.d/blocks/wordpress_locations.conf;
 
     # Remove some CGI sniffing locations
     # HTTP code 444 returned if in map
-    include /etc/nginx/conf.d/blocks/cgi_locations.conf;
+    # include conf.d/blocks/cgi_locations.conf;
 
     # Add SSL headers
-    include /etc/nginx/conf.d/header/ssl_headers.conf;
+    include conf.d/header/ssl_headers.conf;
 
     access_log /var/log/nginx/port443example_access.log;
     error_log /var/log/nginx/port443example_error.log;

--- a/etc/nginx/vhosts.d/examples/reverse_proxy.conf.example
+++ b/etc/nginx/vhosts.d/examples/reverse_proxy.conf.example
@@ -31,6 +31,12 @@ server {
     # HTTP code 444 returned if in map
     include conf.d/blocks/sensitive_locations.conf;
 
+    # Wordpress sniffing URL's if don't host Wordpress you should
+    # use these and if you do then you should probably keep wp-admin
+    # somewhere else
+    # HTTP code 418 returned if in map
+    include conf.d/blocks/wordpress_locations.conf;
+    
     # Remove some CGI sniffing locations
     # HTTP code 444 returned if in map
     include conf.d/blocks/cgi_locations.conf;

--- a/test/http-wordpress.hurl
+++ b/test/http-wordpress.hurl
@@ -1,0 +1,80 @@
+GET https://localhost:8443//2018/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//2019/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//2020/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//blog/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//cms/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//media/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//news/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//shop/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//site/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//sito/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//test/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//web/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//website/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//wordpress/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//wp/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//wp1/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443//wp2/wp-includes/wlwmanifest.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/wordpress/wp-admin/setup-config.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/wp-admin/setup-config.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+


### PR DESCRIPTION
There is several Wordpress site phishing bots and scanners doing their best to find vunerable sites. Add some locations to
prevents most used ones. If you have Wordpress in those locations they should probably be changed or keep Wordpress very up-to-date.

Also added these to examples

New files:
 * etc/nginx/conf.d/blocks/wordpress_map.conf
 * etc/nginx/conf.d/blocks/wordpress_locations.conf