### PR TITLE
Add new special attacks regexps for prevent fishing

### DIFF
--- a/etc/nginx/conf.d/blocks/special_map.conf
+++ b/etc/nginx/conf.d/blocks/special_map.conf
@@ -4,7 +4,7 @@
 map $request_uri $is_uri_special {
     default 0;
     # Ghost
-    "~*/\\x.*" 1;
+    "~*/Gh0st.*" 1;
     # ThinkPHP
     "~*/index.php\?s=.*'wget http.*'.*" 1;
     # PHPStorm
@@ -23,5 +23,86 @@ map $request_uri $is_uri_special {
     "~*/core/img.*" 1;
     # Vendor PHP unit attack
     "~*/vendor/phpunit.*" 1;
-
+    # Random sniffing for attacks
+    "~/(admin|base|default|home|indice|inicio|localstart|login|main|menu|start)\.(asp|php|html|jthml|jsa|jsp|jhtml|inc|pl)" 1;
+    "/+CSCOE+/logon.html" 1;
+    "/Account/Login" 1;
+    "/CFIDE/componentutils/" 1;
+    "/CHANGELOG.txt" 1;
+    "/CSS/Miniweb.css" 1;
+    "/Gj8s" 1;
+    "/IPCamDesc.xml" 1;
+    "/JVqK" 1;
+    "/JaJg" 1;
+    "/Portal/Portal.mwsl" 1;
+    "/Portal0000.htm" 1;
+    "/WebApp/js/UI_String.js" 1;
+    "/__Additional" 1;
+    "/admin/reports/status" 1;
+    "/admin/reports/updates" 1;
+    "/administrator/manifests/files/joomla.xml" 1;
+    "/allversions" 1;
+    "/api/server/version" 1;
+    "/api/v1.0/environment" 1;
+    "/api/v1/check-version" 1;
+    "/api/v2/about" 1;
+    "/api/version" 1;
+    "/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/1" 1;
+    "/build.gradle" 1;
+    "/c/login" 1;
+    "/cluster/list.query" 1;
+    "/config" 1;
+    "/confluence/rest/applinks/1.0/manifest" 1;
+    "/cslu/v1/core/conf" 1;
+    "/css/eonweb.css" 1;
+    "/dana-cached/hc/HostCheckerInstaller.osx" 1;
+    "/dana-na/nc/nc_gina_ver.txt" 1;
+    "/dniapi/userInfos" 1;
+    "/docs/cplugError.html/" 1;
+    "/ed1b" 1;
+    "/ext-js/app/common/zld_product_spec.js" 1;
+    "/favicon.ico" 1;
+    "~/fog/management/index.php.*" 1;
+    "/geoserver/" 1;
+    "/geoserver/index.html" 1;
+    "/geoserver/web/wicket/bookmarkable/org.geoserver.web.AboutGeoServerPage" 1;
+    "/health" 1;
+    "/helpdesk/WebObjects/Helpdesk.woa" 1;
+    "~/human.aspx.*" 1;
+    "/index.asp" 1;
+    "/index.aspx" 1;
+    "/index.jhtml" 1;
+    "/index.jsa" 1;
+    "/index.pl" 1;
+    "/info.asp" 1;
+    "/javascript/validation/OEM.js" 1;
+    "/kylin/" 1;
+    "/language/en-GB/en-GB.xml" 1;
+    "/lms/db" 1;
+    "/login/login.html" 1;
+    "/magento_version" 1;
+    "/nk5N" 1;
+    "~/nmaplowercheck.*" 1;
+    "/owa/" 1;
+    "/p/login/" 1;
+    "/pandora_console/" 1;
+    "/pom.xml" 1;
+    "/pools" 1;
+    "/pools/default/buckets" 1;
+    "/portal/" 1;
+    "/pvA5" 1;
+    "/r-seenet/index.php" 1;
+    "/r51201%2C/desktop%2C/utility/flag.js" 1;
+    "/r51287%2C/desktop%2C/utility/flag.js" 1;
+    "/readme.txt" 1;
+    "/rest/applinks/1.0/manifest" 1;
+    "/robots.txt" 1;
+    "/sULH" 1;
+    "/status" 1;
+    "/tos/index.php?user/login" 1;
+    "/user" 1;
+    "/versa/login" 1;
+    "/versions" 1;
+    "/webui" 1;
+    "/xml/info.xml" 1;
 }

--- a/etc/nginx/conf.d/max_map.conf
+++ b/etc/nginx/conf.d/max_map.conf
@@ -1,0 +1,10 @@
+# Sets the bucket size for the map variables hash tables.
+# Default value depends on the processor’s cache line size.
+# The details of setting up hash tables are provided in a separate document. 
+# https://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_bucket_size
+map_hash_bucket_size 256;
+
+# Sets the maximum size of the map variables hash tables.
+# The details of setting up hash tables are provided in a separate document. 
+# https://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_max_size
+map_hash_max_size 4096;

--- a/test/http-special.hurl
+++ b/test/http-special.hurl
@@ -1,0 +1,671 @@
+GET https://localhost:8443/+CSCOE+/logon.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/Account/Login
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/CFIDE/componentutils/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/CHANGELOG.txt
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/CSS/Miniweb.css
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/Gj8s
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/IPCamDesc.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/JVqK
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/JaJg
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/Portal/Portal.mwsl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/Portal0000.htm
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/WebApp/js/UI_String.js
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/__Additional
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin/reports/status
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/admin/reports/updates
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/administrator/manifests/files/joomla.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/allversions
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/api/server/version
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/api/v1.0/environment
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/api/v1/check-version
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/api/v2/about
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/api/version
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/1
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.inc
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/base.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/build.gradle
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/c/login
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/cluster/list.query
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/config
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/confluence/rest/applinks/1.0/manifest
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/cslu/v1/core/conf
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/css/eonweb.css
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/dana-cached/hc/HostCheckerInstaller.osx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/dana-na/nc/nc_gina_ver.txt
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/default.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/dniapi/userInfos
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/docs/cplugError.html/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/ed1b
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/ext-js/app/common/zld_product_spec.js
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/fog/management/index.php?node=client&sub=logininfo
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/geoserver/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/geoserver/index.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/geoserver/web/wicket/bookmarkable/org.geoserver.web.AboutGeoServerPage
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/health
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/helpdesk/WebObjects/Helpdesk.woa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/home.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/human.aspx?arg12=infotech
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/index.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/index.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/index.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/index.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/index.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/indice.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/info.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/inicio.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/javascript/validation/OEM.js
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/kylin/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/language/en-GB/en-GB.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/lms/db
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/localstart.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/login.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/login.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/login.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/login/login.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/magento_version
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/main.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/menu.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nk5N
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1739993787
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1741607384
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1742544822
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1744175816
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1744262182
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1744958788
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/nmaplowercheck1745454709
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/owa/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/p/login/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/pandora_console/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/pom.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/pools
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/pools/default/buckets
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/portal/
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/pvA5
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/r-seenet/index.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/r51201%2C/desktop%2C/utility/flag.js
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/r51287%2C/desktop%2C/utility/flag.js
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/readme.txt
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/rest/applinks/1.0/manifest
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/sULH
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.asp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.aspx
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.html
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.jhtml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.jsa
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.jsp
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.php
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/start.pl
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/status
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/tos/index.php?user/login
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/user
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/versa/login
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/versions
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/webui
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418
+
+GET https://localhost:8443/xml/info.xml
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
+HTTP 418


### PR DESCRIPTION
There is lot of fishing attacks that just goes thru some list. Add one set of them and Hurl tests to make sure that they are greeted with 418

also add new config file: etc/nginx/conf.d/max_map.conf which adds two new configs:
  * map_hash_bucket_size 256;
  * map_hash_max_size 4096;