### PR TITLE
Update HURL to 6.1.0

### DIFF
--- a/.github/workflows/reusable-test-nginx.yml
+++ b/.github/workflows/reusable-test-nginx.yml
@@ -33,8 +33,8 @@ jobs:
         run: apt install -y libcurl4 curl lsof nginx procps psmisc libxml2
       - name: Install package 'hurl'
         run: |
-             curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
-             dpkg -i hurl_5.0.1_amd64.deb
+             curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/6.0.0/hurl_6.0.0_amd64.deb
+             dpkg -i hurl_6.0.0_amd64.deb
       - name: Copy config(s) to '/etc/nginx'
         run: |
              cp etc/nginx/nginx.conf.nginx-config /etc/nginx/nginx.conf


### PR DESCRIPTION
Update HURL to version 6.1.0 to keep up with newer version and make sure that Debian Sid does not sigsegv on tests