### PR TITLE
Make sure that Nextcloud SVG files are served correctly

### DIFF
--- a/etc/nginx/conf.d/blocks/special_map.conf
+++ b/etc/nginx/conf.d/blocks/special_map.conf
@@ -19,8 +19,6 @@ map $request_uri $is_uri_special {
     "~*/Autodiscover/Autodiscover.xml.*" 1;
     # Laravel attack
     "~*/_ignition/execute-solution.*" 1;
-    # Laravel sniff attack
-    "~*/core/img.*" 1;
     # Vendor PHP unit attack
     "~*/vendor/phpunit.*" 1;
     # Random sniffing for attacks
@@ -69,6 +67,9 @@ map $request_uri $is_uri_special {
     "/cgi-bin/wp-login.php" 1;
     "/c/login" 1;
     "/cluster/list.query" 1;
+    "/core/img/favicon.ico" 1;
+    "/core/img/favicon-touch.png" 1;
+    "/core/img/favicon-mask.svg" 1;
     "/config" 1;
     "/config/env.prod.json" 1;
     "/confluence/rest/applinks/1.0/manifest" 1;

--- a/test/http-nextcloud.hurl
+++ b/test/http-nextcloud.hurl
@@ -1,0 +1,19 @@
+GET https://localhost:8443/core/img/actions/share.svg
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0
+HTTP 404
+
+GET https://localhost:8443/core/img/actions/settings-dark.svg
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0
+HTTP 404
+
+GET https://localhost:8443/core/img/favicon.ico
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0
+HTTP 418
+
+GET https://localhost:8443/core/img/favicon-touch.png
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0
+HTTP 418
+
+GET https://localhost:8443/core/img/favicon-mask.svg
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0
+HTTP 418


### PR DESCRIPTION
Make sure that Nextcloud SVG files are served correctly. Current block was too generic and needed tuning for attack vector.

 * Update special_map with /core/img/favicon.ico /core/img/favicon-touch.png /core/img/favicon-mask.svg

Add also HURL test that this should not happend anymore